### PR TITLE
Make the output easier to read.

### DIFF
--- a/MethodTransformVisitor.java
+++ b/MethodTransformVisitor.java
@@ -45,14 +45,14 @@ class MethodTransformVisitor extends MethodVisitor implements Opcodes {
 
     @Override
     public void visitEnd() {
-        System.out.println("    Number of Arguments: " + numParams);
-        System.out.println("    Number of Var Declarations: " + numVars);
-        System.out.println("    Number of Lines: " + lineCount);
-        System.out.println("    Number of Arith/Bitwise Operators: " + numOperators);
-        System.out.println("    Number of Arith/Bitwise Operands: " + numOperands);
-        System.out.println("    Number of Loops: " + numLoops);
-        System.out.println("    Number of Casts: " + numCasts);
-        System.out.println("    Number of Var References: " + varReferences.size());
+        System.out.println("    No. of Arguments:                " + numParams);
+        System.out.println("    No. of Var Declarations:         " + numVars);
+        System.out.println("    No. of Lines:                    " + lineCount);
+        System.out.println("    No. of Arith/Bitwise Operators:  " + numOperators);
+        System.out.println("    No. of Arith/Bitwise Operands:   " + numOperands);
+        System.out.println("    No. of Loops:                    " + numLoops);
+        System.out.println("    No. of Casts:                    " + numCasts);
+        System.out.println("    No. of Variables Referenced:     " + varReferences.size());
 
         System.out.println("    Local Method invocations: " + (localMethodsCalled.isEmpty() ? "None" : ""));
         for (String method:localMethodsCalled)


### PR DESCRIPTION
Just wanted to make the output easier to read so now all the numbers are on the same margin. It used to be like this:
```
  Function name: testThisFunction
    Modifiers: public 
    Number of Arguments: 0
    Number of Var Declarations: 1
    Number of Lines: 6
    Number of Arith/Bitwise Operators: 1
    Number of Arith/Bitwise Operands: 1
    Number of Loops: 3
    Number of Casts: 0
    Number of Variables Referenced: 1
    Local Method invocations: None
    External Method invocations: None
    Exceptions referenced: 
```
Now it is like this:

```
  Function name: testThisFunction
    Modifiers: public 
    No. of Arguments:                0
    No. of Var Declarations:         1
    No. of Lines:                    6
    No. of Arith/Bitwise Operators:  1
    No. of Arith/Bitwise Operands:   1
    No. of Loops:                    3
    No. of Casts:                    0
    No. of Variables Referenced:     1
    Local Method invocations: None
    External Method invocations: None
    Exceptions referenced: 
```